### PR TITLE
feat: use build cache only when actually building...

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,7 @@ runs:
         key: build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
           build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
+      if: inputs.build-deps == 'true' or inputs.build-app == 'true'
 
     - name: Get Hex cache
       uses: actions/cache@v3


### PR DESCRIPTION
to prevent the cache from being useless